### PR TITLE
Drop issue 5276 from bugs as no actual fixes introduced

### DIFF
--- a/v1.5.0.md
+++ b/v1.5.0.md
@@ -287,7 +287,6 @@ Harvester v1.5.0 fully supports deployment on hosts with ARM architecture. This 
 - [BUG] VM cannot fully utilize the defined Resource Quota (Memory Limit)  [#6293](https://github.com/harvester/harvester/issues/6293)
 - [BUG] Creating an IPPool whose name differs from its associated network's causes IP allocation issues for Managed DHCP [#6240](https://github.com/harvester/harvester/issues/6240)
 - [BUG] Rancher deployed on arm machines cannot provision Harvester VM's [#6053](https://github.com/harvester/harvester/issues/6053)
-- [BUG] No IP address assigned and display on virtual machine when create vm with two vlan network   [#5276](https://github.com/harvester/harvester/issues/5276)
 - [BUG/FEATURE] Harvester mgmt network blocks specific HTTPS traffic on attached VLANs [#4359](https://github.com/harvester/harvester/issues/4359)
 - [BUG] Unable to create Cluster Output/ Output via edit yaml [#3877](https://github.com/harvester/harvester/issues/3877)
 - [BUG] Prometheus has warning message of `Evaluating rule failed` against KubeVirtComponentExceedsRequestedMemory [#3792](https://github.com/harvester/harvester/issues/3792)


### PR DESCRIPTION
As we don't have actual code-level fixes or doc updates for the issue, we don't need the issue listed in the release note.

As a side note, this should not happen if we add the relevant label, i.e., `not-require/release-note`. The release note generating script will then exclude them.