### PR TITLE
Add note about issue #8534 and rewrite note about RKE EOL in v1.5.1 RN

### DIFF
--- a/v1.5.1.md
+++ b/v1.5.1.md
@@ -8,7 +8,7 @@ The Harvester team appreciates your contributions and looks forward to receiving
 >
 > A [Longhorn issue](https://github.com/longhorn/longhorn/issues/11158) causes virtual machines that use migratable [RWX volumes](https://docs.harvesterhci.io/v1.5/rancher/csi-driver/#rwx-volumes-support) to restart unexpectedly when the CSI plugin pods are restarted. The issue affects Harvester v1.4.x, v1.5.0, and v1.5.1.
 >
-> You can work around it by disabling the **Storage Network for RWX Volume Enabled** setting on the [embedded Longhorn UI](https://docs.harvesterhci.io/v1.5/troubleshooting/harvester/#access-embedded-rancher-and-longhorn-dashboards). The issue will be fixed in Longhorn {versions}, which will be included in Harvester {versions}. For more information, see GitHub issues [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158).
+> You can work around it by disabling the **Storage Network for RWX Volume Enabled** setting on the [embedded Longhorn UI](https://docs.harvesterhci.io/v1.5/troubleshooting/harvester/#access-embedded-rancher-and-longhorn-dashboards). The issue will be fixed in Longhorn v1.8.3, v1.9.1, and later versions. Harvester v1.6.0 will include Longhorn v1.9.1. For more information, see GitHub issues [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158).
 
 > [!IMPORTANT]
 >

--- a/v1.5.1.md
+++ b/v1.5.1.md
@@ -6,9 +6,11 @@ The Harvester team appreciates your contributions and looks forward to receiving
 
 > [!CAUTION]
 >
-> A [Longhorn issue](https://github.com/longhorn/longhorn/issues/11158) causes virtual machines that use migratable [RWX volumes](https://docs.harvesterhci.io/v1.5/rancher/csi-driver/#rwx-volumes-support) to restart unexpectedly when the CSI plugin pods are restarted. The issue affects Harvester v1.4.x, v1.5.0, and v1.5.1.
+> A [Longhorn issue](https://github.com/longhorn/longhorn/issues/11158) causes virtual machines that use migratable [RWX volumes](https://docs.harvesterhci.io/v1.5/rancher/csi-driver/#rwx-volumes-support) to restart unexpectedly when the CSI plugin pods are restarted. This issue affects Harvester v1.4.x, v1.5.0, and v1.5.1.
 >
-> You can work around it by disabling the **Storage Network for RWX Volume Enabled** setting on the [embedded Longhorn UI](https://docs.harvesterhci.io/v1.5/troubleshooting/harvester/#access-embedded-rancher-and-longhorn-dashboards). The issue will be fixed in Longhorn v1.8.3, v1.9.1, and later versions. Harvester v1.6.0 will include Longhorn v1.9.1. For more information, see GitHub issues [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158).
+> The workaround is to disable the setting [Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly](https://longhorn.io/docs/1.8.0/references/settings/#automatically-delete-workload-pod-when-the-volume-is-detached-unexpectedly) on the Longhorn UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+> 
+> The issue will be fixed in Longhorn v1.8.3, v1.9.1, and later versions. Harvester v1.6.0 will include Longhorn v1.9.1. For more information, see GitHub issues [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158).
 
 > [!IMPORTANT]
 >

--- a/v1.5.1.md
+++ b/v1.5.1.md
@@ -12,9 +12,9 @@ The Harvester team appreciates your contributions and looks forward to receiving
 
 > [!IMPORTANT]
 >
-> Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. Harvester **v1.6.0** and later versions will not support RKE. Switching to RKE2, which provides a more secure and efficient environment, is recommended.
+> Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. Starting with Harvester **v1.6.0**, you will not be able to run Rancher-provisioned RKE clusters on top of Harvester. Switching guest workloads to RKE2, which provides a more secure and efficient environment, is strongly recommended.
 >
-> In-place upgrades are not an option, so you must [create new RKE2 clusters](https://docs.harvesterhci.io/v1.5/rancher/node/rke2-cluster) and migrate the workloads from your existing RKE clusters (known as replatforming). For more information, see [RKE End of Life](https://www.suse.com/support/kb/doc/?id=000021513).
+> You must [create new RKE2 clusters](https://docs.harvesterhci.io/v1.5/rancher/node/rke2-cluster) and subsequently migrate the workloads from your existing RKE clusters. In-place migration from RKE to RKE2 is not an option because of possible data loss. For more information, see [RKE End of Life](https://www.suse.com/support/kb/doc/?id=000021513).
 
 ## Downloads
 

--- a/v1.5.1.md
+++ b/v1.5.1.md
@@ -6,6 +6,12 @@ The Harvester team appreciates your contributions and looks forward to receiving
 
 > [!CAUTION]
 >
+> A [Longhorn issue](https://github.com/longhorn/longhorn/issues/11158) causes virtual machines that use migratable [RWX volumes](https://docs.harvesterhci.io/v1.5/rancher/csi-driver/#rwx-volumes-support) to restart unexpectedly when the CSI plugin pods are restarted. The issue affects Harvester v1.4.x, v1.5.0, and v1.5.1.
+>
+> You can work around it by disabling the **Storage Network for RWX Volume Enabled** setting on the [embedded Longhorn UI](https://docs.harvesterhci.io/v1.5/troubleshooting/harvester/#access-embedded-rancher-and-longhorn-dashboards). The issue will be fixed in Longhorn {versions}, which will be included in Harvester {versions}. For more information, see GitHub issues [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158).
+
+> [!IMPORTANT]
+>
 > Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. Harvester **v1.6.0** and later versions will not support RKE. Switching to RKE2, which provides a more secure and efficient environment, is recommended.
 >
 > In-place upgrades are not an option, so you must [create new RKE2 clusters](https://docs.harvesterhci.io/v1.5/rancher/node/rke2-cluster) and migrate the workloads from your existing RKE clusters (known as replatforming). For more information, see [RKE End of Life](https://www.suse.com/support/kb/doc/?id=000021513).


### PR DESCRIPTION
Related issues: [#8534](https://github.com/harvester/harvester/issues/8534) and [#11158](https://github.com/longhorn/longhorn/issues/11158)

Changes:
- Add "Caution" note about VM restart issue to general introduction
- Rewrite note about RKE EOL per feedback and change label from "Caution" to "Important" for better differentiation